### PR TITLE
Add ESCN verifier api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Local development with maven
 
-Compile the porject and publish it to your local maven repository:
+Compile the project and publish it to your local maven repository:
 
 ```bash
 ./gradlew publishToMavenLoca

--- a/src/main/kotlin/eu/eduTap/core/router/ESCRouterPayloads.kt
+++ b/src/main/kotlin/eu/eduTap/core/router/ESCRouterPayloads.kt
@@ -81,6 +81,21 @@ data class CardLite(
 )
 
 @Serializable
+data class CardVerified(
+  val cardNumber: String,
+  val cardType: Card.TypedKeyLabel<CardType>,
+  val cardStatusType: Card.TypedKeyLabel<CardStatusType>,
+  val expiresAt: String,
+  val issuer: Issuer,
+) {
+  @Serializable
+  data class Issuer(
+    val identifier: String,
+    val name: String,
+  )
+}
+
+@Serializable
 data class CardPerson(
   val fullName: String,
   val identifier: String,

--- a/src/main/kotlin/eu/eduTap/core/router/ESCRouterPayloads.kt
+++ b/src/main/kotlin/eu/eduTap/core/router/ESCRouterPayloads.kt
@@ -81,7 +81,7 @@ data class CardLite(
 )
 
 @Serializable
-data class CardVerified(
+data class CardVerificationDetails(
   val cardNumber: String,
   val cardType: Card.TypedKeyLabel<CardType>,
   val cardStatusType: Card.TypedKeyLabel<CardStatusType>,

--- a/src/main/kotlin/eu/eduTap/core/router/VerifyApi.kt
+++ b/src/main/kotlin/eu/eduTap/core/router/VerifyApi.kt
@@ -1,0 +1,22 @@
+package eu.eduTap.core.router
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+class VerifyApi(httpClient: HttpClient, apiUrl: String) : ESCApi(httpClient, apiUrl) {
+  private val cardApiUrl = "${apiUrl}cards/verify"
+
+  suspend fun escn(escn: String): CardVerified {
+
+    val verifiedCard = makeRequest<CardVerified> {
+      httpClient.get(cardApiUrl) {
+        url {
+          appendPathSegments(escn)
+        }
+      }
+    }
+
+    return verifiedCard
+  }
+}

--- a/src/main/kotlin/eu/eduTap/core/router/VerifyApi.kt
+++ b/src/main/kotlin/eu/eduTap/core/router/VerifyApi.kt
@@ -7,9 +7,16 @@ import io.ktor.http.*
 class VerifyApi(httpClient: HttpClient, apiUrl: String) : ESCApi(httpClient, apiUrl) {
   private val cardApiUrl = "${apiUrl}cards/verify"
 
-  suspend fun escn(escn: String): CardVerified {
+  /**
+   * Verify a card using its ESCN (European Student Card Number).
+   *
+   * @param escn The ESCN of the card to verify.
+   * @return A [CardVerificationDetails] object containing the verification details of the card.
+   * @throws ESCRouterApiException with code `ER-0001` in case no card with the given [escn] exists.
+   */
+  suspend fun escn(escn: String): CardVerificationDetails {
 
-    val verifiedCard = makeRequest<CardVerified> {
+    val verifiedCard = makeRequest<CardVerificationDetails> {
       httpClient.get(cardApiUrl) {
         url {
           appendPathSegments(escn)


### PR DESCRIPTION
Add API for verifying cards by their escn.
This API is public and allows to verify any ESCN also if you aren't associated with the issuing organization on the ESC-Router. It is not possible to get personal details via this API.

See request which is triggered on e.g. https://p.esc-r.eu/02299a90-78fd-103d-ba39-988299459830.
There is also a "official" verification java client (https://github.com/EuropeanStudentCard/escn-java-validator-client). Note that the url used there does not work (path prefix "esc-verifier-service" is missing).

@functionaldude not sure if it is really necessary to create two HTTP clients. Maybe we could even create an own class for all unauthenticated APIs and one which adds all the authenticated APIs on top?